### PR TITLE
Add support for SCSS

### DIFF
--- a/src/main/kotlin/com/mallowigi/focusmode/extensions/ScssFocusedElementFinder.kt
+++ b/src/main/kotlin/com/mallowigi/focusmode/extensions/ScssFocusedElementFinder.kt
@@ -21,10 +21,10 @@ package com.mallowigi.focusmode.extensions
 
 import com.intellij.psi.PsiElement
 import com.intellij.psi.css.CssBlock
-import org.jetbrains.plugins.sass.SASSLanguage
+import org.jetbrains.plugins.scss.SCSSLanguage
 import org.jetbrains.plugins.scss.psi.SassScssBlock
 
-class SassFocusedElementFinder : AbstractFocusedElementFinder(SASSLanguage.INSTANCE) {
+class ScssFocusedElementFinder : AbstractFocusedElementFinder(SCSSLanguage.INSTANCE) {
   override fun isFocusParent(element: PsiElement): Boolean =
     element is SassScssBlock || element is CssBlock
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -23,6 +23,7 @@
   <depends optional="true" config-file="withPython.xml">Pythonid</depends>
   <depends optional="true" config-file="withGo.xml">org.jetbrains.plugins.go</depends>
   <depends optional="true" config-file="withSass.xml">org.jetbrains.plugins.sass</depends>
+  <depends optional="true" config-file="withScss.xml">org.jetbrains.plugins.sass</depends>
 
   <resource-bundle>messages.FocusModeBundle</resource-bundle>
 

--- a/src/main/resources/META-INF/withScss.xml
+++ b/src/main/resources/META-INF/withScss.xml
@@ -1,0 +1,33 @@
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  ~ The MIT License (MIT)
+  ~
+  ~ Copyright (c) 2015-2022 Elior "Mallowigi" Boukhobza
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~ SOFTWARE.
+  ~
+  ~
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+
+<idea-plugin>
+    <extensions defaultExtensionNs="com.mallowigi">
+        <focusmode.focusedElementFinder
+                implementation="com.mallowigi.focusmode.extensions.ScssFocusedElementFinder"/>
+    </extensions>
+
+</idea-plugin>


### PR DESCRIPTION
Although there was a support for SASS files already present, it did not work in case when file had a .SCSS extension.

This was due to the fact that JetBrains has a dedicated implementation for SCSS, so `SASSLanguage` was not recognized as a proper `FocusedElementFinder`.

This commit fixes it by introducing additional `ScssFocusedElementFinder` which mimics the behaviouir of `SassFocusedElementFinder`.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>